### PR TITLE
update image ubuntu deprecated

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:kinetic
+FROM ubuntu:jammy
 
 ARG AIRFLOW_HOME=/home/airflow
 


### PR DESCRIPTION
Versão do ubuntu do airflow não possui mais compatibilidade. Não criando a imagem no docker ao fazer o update.